### PR TITLE
repleace `Token::Token::` with `Token::`

### DIFF
--- a/Chapter02/calc/src/Lexer.cpp
+++ b/Chapter02/calc/src/Lexer.cpp
@@ -46,10 +46,10 @@ CASE('+', Token::plus);
 CASE('-', Token::minus);
 CASE('*', Token::star);
 CASE('/', Token::slash);
-CASE('(', Token::Token::l_paren);
-CASE(')', Token::Token::r_paren);
-CASE(':', Token::Token::colon);
-CASE(',', Token::Token::comma);
+CASE('(', Token::l_paren);
+CASE(')', Token::r_paren);
+CASE(':', Token::colon);
+CASE(',', Token::comma);
 #undef CASE
     default:
       formToken(token, BufferPtr + 1, Token::unknown);


### PR DESCRIPTION
I think `Token::Token::` should be a typo.